### PR TITLE
feat/without-data-wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ By default user used to perform requests is created by user factory `User::facto
         return $user;
     }
 
+# Without `data` wrapping
+
+By default every response is wrapped into `data`. If you remove wrapping from responses, then you also should remove wrapping from crudable tests.
+To remove wrapping while testing json structure, just put method names into array within `withoutDataWrap` method.
+
+    protected function withoutDataWrap(): array
+    {
+        return ['show', 'store', 'update'];
+    }
+
 # Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/src/Blueprints/CrudableTest.php
+++ b/src/Blueprints/CrudableTest.php
@@ -46,4 +46,9 @@ class CrudableTest extends TestCase
     {
         return null;
     }
+
+    protected function withoutDataWrap(): array
+    {
+        return [];
+    }
 }

--- a/src/Commands/CreateCrudableTestCommand.php
+++ b/src/Commands/CreateCrudableTestCommand.php
@@ -162,11 +162,11 @@ EOT;
             ->json('GET', route(\$this->getPrefix() . '.show', [Str::snake(class_basename(\$model)) => \$object->id]));
 
         \$response->assertOk()
-            ->assertJson([
-                'data' => [
+            ->assertJson(
+                !in_array('show', \$this->withoutDataWrap()) ? ['data' => [
                     'id' => \$object->id,
-                ],
-            ])->assertJsonStructure(\$this->getStructureFor(\$object));
+                ]] : ['id' => \$object->id],
+            )->assertJsonStructure(\$this->getStructureFor(\$object));
     }
 EOT;
     }
@@ -184,7 +184,7 @@ EOT;
             ->withHeaders(\$this->defaultHeaders())
             ->json('POST', route(\$this->getPrefix() . '.store'), \$objectToInsert->toArray());
 
-        \$response->assertCreated()->assertJsonStructure(['data' => ['id']])
+        \$response->assertCreated()->assertJsonStructure(!in_array('store', \$this->withoutDataWrap()) ? ['data' => ['id']] : ['id'])
             ->assertJsonStructure(\$this->getStructureFor(\$objectToInsert));
     }
 EOT;
@@ -202,7 +202,7 @@ EOT;
             ->withHeaders(\$this->defaultHeaders())
             ->json('PATCH', route(\$this->getPrefix() . '.update', [Str::snake(class_basename(\$model)) => \$object->id]), \$model::factory()->make()->toArray());
 
-        \$response->assertOk()->assertJsonStructure(['data' => ['id']])
+        \$response->assertOk()->assertJsonStructure(!in_array('update', \$this->withoutDataWrap()) ? ['data' => ['id']] : ['id'])
             ->assertJsonStructure(\$this->getStructureFor(\$object));
     }
 EOT;


### PR DESCRIPTION
Added feature that adds possibility to remove 'data' wrapping from testing json structure